### PR TITLE
fix: latest tag

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -64,7 +64,7 @@ get_download_url() {
   local filename
   filename="$(get_filename "$version" "$platform" "$binary_name")"
 
-  echo "https://github.com/hadolint/hadolint/releases/download/${version}/${filename}"
+  echo "https://github.com/hadolint/hadolint/releases/download/v${version}/${filename}"
 }
 
 tmp_download_dir="$(mktemp -d -t 'asdf_XXXXXXXX')"

--- a/bin/list-all
+++ b/bin/list-all
@@ -15,6 +15,6 @@ function sort_versions() {
 }
 
 # Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions)
+versions=$(eval "$cmd" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
 # shellcheck disable=SC2086
 echo $versions


### PR DESCRIPTION
fix: #3 
running `asdf install hadolint latest` would return `No compatible versions available (hadolint [0-9])`. The reason is that in list file the version is not trimmed properly

test after the fix:
```bash
$ asdf install hadolint latest
Downloading [hadolint] from https://github.com/hadolint/hadolint/releases/download/v2.10.0/hadolint-Linux-x86_64 to /tmp/asdf_gmVh0HhA/hadolint-Linux-x86_64
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 2247k  100 2247k    0     0  12.2M      0 --:--:-- --:--:-- --:--:-- 12.2M
Creating bin directory
Cleaning previous binaries
Copying binary
```
list installed versions:
```
$ asdf list hadolint
  2.10.0
```